### PR TITLE
trimesh with version >= 3.11.2 returns vertices in different order

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,5 @@
 [MESSAGES CONTROL]
-# C0330: Wrong hanging indentation before block (conflicts with black, see https://github.com/psf/black/issues/48)
-disable=bad-continuation
+disable=
 
 [SIMILARITIES]
 # Minimum lines number of a similarity.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,4 @@ Changelog
 
 Version 0.1.0
 -------------
-- Initial commit: extracts `placement_hints`, `distances` and related tests from `nse/atlas-building-tools` [`NSETM_1685_`]
-
-
-.. _`NSETM-1685`: https://bbpteam.epfl.ch/project/issues/browse/NSETM-1685
+- Initial commit: extracts `placement_hints`, `distances` and related tests from `nse/atlas-building-tools`

--- a/atlas_placement_hints/app/placement_hints.py
+++ b/atlas_placement_hints/app/placement_hints.py
@@ -1,7 +1,4 @@
 """Generate and save the placement hints of different regions of the AIBS mouse brain
-
-See https://bbpteam.epfl.ch/documentation/projects/placement-algorithm/latest/index.html
-for the specifications of the placement hints.
 """
 from __future__ import annotations
 
@@ -152,9 +149,6 @@ def app():
     interpolation, with the placement hints of nearby voxels,
     - 2 means that a problem persisted after interpolation,
     - 3 means that a problem was created by interpolation.
-
-    For the definition of the placement hints, see:
-    https://bbpteam.epfl.ch/documentation/projects/placement-algorithm/latest/index.html#input-data
     """
 
 

--- a/atlas_placement_hints/distances/distances_to_meshes.py
+++ b/atlas_placement_hints/distances/distances_to_meshes.py
@@ -554,7 +554,7 @@ def interpolate_problematic_distances(
     for layered_hemisphere in layered_volumes:
         for label in np.unique(layered_hemisphere[layered_hemisphere != 0]):
             layer_mask = layered_hemisphere == label
+            valid = np.logical_and(layer_mask, ~problematic_mask)
+            invalid = np.logical_and(layer_mask, problematic_mask)
             for distance in distances:
-                valid = np.logical_and(layer_mask, ~problematic_mask)
-                invalid = np.logical_and(layer_mask, problematic_mask)
                 interpolate_scalar_field(distance, invalid, valid)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@ Documentation
 
 The project `atlas-placement-hints` offers tools to build brain region atlases.
 In BBP terminology, an atlas is a bundle of files, mostly volumetric nrrd_ files, which allows
-to navigate brain regions and to `place cells`_. Atlases are consumed by the `circuit building`_ pipeline.
+to navigate brain regions.
 
 Tools are made available through a :ref:`cli`.
 
@@ -16,5 +16,3 @@ Tools are made available through a :ref:`cli`.
 
 
 .. _nrrd: http://teem.sourceforge.net/nrrd/format.html
-.. _`place cells`: https://bbpteam.epfl.ch/documentation/projects/placement-algorithm/latest/index.html
-.. _`circuit building`: https://bbpteam.epfl.ch/documentation/projects/circuit-build/latest/tutorial.html

--- a/tests/placement_hints/test_utils.py
+++ b/tests/placement_hints/test_utils.py
@@ -48,9 +48,12 @@ def test_centroid_outfacing_mesh():
     # The centroid lies outside of the mesh
     vertices = [[-1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 0, 0.8]]
     faces = [[0, 1, 3], [0, 3, 2], [3, 1, 2], [0, 2, 4], [0, 4, 1], [1, 4, 2]]
+
     mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
-    expected_vertices = [[0, 0, 1], [0, 1, 0], [-1, 0, 0], [1, 0, 0]]
-    expected_faces = [[2, 3, 0], [2, 0, 1], [0, 3, 1]]
+    expected_vertices = np.array(
+        [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    )
+    expected_faces = np.array([[0, 1, 3], [0, 3, 2], [3, 1, 2]])
     result = tested.centroid_outfacing_mesh(mesh)
     npt.assert_array_equal(result.vertices, expected_vertices)
     npt.assert_array_equal(result.faces, expected_faces)


### PR DESCRIPTION
Old
    expected_vertices = [[0, 0, 1],
                         [0, 1, 0],
                         [-1, 0, 0],
                         [1, 0, 0]]
    expected_faces = [[2, 3, 0],
                      [2, 0, 1],
                      [0, 3, 1]]

Gets translated to the new vertices with:
 0 -> 3
 1 -> 2
 2 -> 0
 3 -> 1