### PR TITLE
Hotfix: Add arg detection for overloading

### DIFF
--- a/atlas_placement_hints/compute_placement_hints.py
+++ b/atlas_placement_hints/compute_placement_hints.py
@@ -70,12 +70,23 @@ def compute_placement_hints(
                 least one distance-related problem.
                 See distances.distance_to_meshes.report_distance_problems doc.
     """
-    distances_info = atlas.compute_distances_to_layer_boundaries(
-        direction_vectors,
-        flip_direction_vectors=flip_direction_vectors,
-        has_hemispheres=has_hemispheres,
-        thalamus_meshes_dir=thalamus_meshes_dir,
-    )
+
+    if thalamus_meshes_dir == "":
+        # Use either the AbstractLayeredAtlas or VoxelBasedLayeredAtlas version if
+        # no meshes are provided
+        distances_info = atlas.compute_distances_to_layer_boundaries(
+            direction_vectors,
+            flip_direction_vectors=flip_direction_vectors,
+            has_hemispheres=has_hemispheres,
+        )
+    else:
+        # Use the MeshBasedLayeredAtlas version if meshes are provided
+        distances_info = atlas.compute_distances_to_layer_boundaries(
+            direction_vectors,
+            flip_direction_vectors=flip_direction_vectors,
+            has_hemispheres=has_hemispheres,
+            thalamus_meshes_dir=thalamus_meshes_dir,
+        )
 
     distances_to_meshes = distances_info["distances_to_layer_boundaries"]
     tolerance = 2.0 * atlas.region.voxel_dimensions[0]


### PR DESCRIPTION
This fixes #25 by customizing the calls to the overloaded function `compute_distances_to_layer_boundaries`. Since there is only one definition of `compute_placement_hints`, this should solve the problem in all cases. This has been tested against the exact command and data that @lecriste provided in #25 along with some other cases, and all `tox` tests have passed locally.